### PR TITLE
Fix proxy config change handling.

### DIFF
--- a/connect/proxy/listener_test.go
+++ b/connect/proxy/listener_test.go
@@ -223,4 +223,9 @@ func TestUpstreamListener(t *testing.T) {
 	// Check all the tx/rx counters got added
 	assertAllTimeCounterValue(t, sink, "consul.proxy.test.upstream.tx_bytes;src=web;dst_type=service;dst=db", 11)
 	assertAllTimeCounterValue(t, sink, "consul.proxy.test.upstream.rx_bytes;src=web;dst_type=service;dst=db", 11)
+
+	// Ensure that when the listener is closed the port is actually released.
+	_, err = net.Dial("tcp",
+		ipaddr.FormatAddressPort(cfg.LocalBindAddress, cfg.LocalBindPort))
+	require.Error(t, err, "listener port not released")
 }

--- a/connect/proxy/proxy_test.go
+++ b/connect/proxy/proxy_test.go
@@ -79,3 +79,88 @@ func TestProxy_public(t *testing.T) {
 	// Connection works, test it is the right one
 	TestEchoConn(t, conn, "")
 }
+
+func TestProxy_upstreamChanges(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	require := require.New(t)
+
+	ports := freeport.MustTake(3)
+	defer freeport.Return(ports)
+
+	a := agent.NewTestAgent(t, "")
+	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+	client := a.Client()
+
+	// Start the proxy with two upstreams.
+	cfg := NewStaticConfigWatcher(&Config{
+		ProxiedServiceName: "fake",
+		Upstreams: []UpstreamConfig{
+			{
+				DestinationName: "upstream1",
+				LocalBindPort:   ports[0],
+			},
+			{
+				DestinationName: "upstream2",
+				LocalBindPort:   ports[1],
+			},
+		},
+	})
+	p, err := New(client, cfg, testutil.Logger(t))
+	require.NoError(err)
+	defer p.Close()
+	go p.Serve()
+
+	// Check that the expected ports are listening. There are no actual upstreams
+	// so we just check that the ports are listening.
+	requirePortIsListening(t, ports[0])
+	requirePortIsListening(t, ports[1])
+	requirePortIsNotListening(t, ports[2])
+
+	// Update the configuration to change the ports:
+	//   ports[0] is droppped
+	//   ports[1] is re-used
+	//   ports[2] is added
+	cfg.ch <- &Config{
+		ProxiedServiceName: "fake",
+		Upstreams: []UpstreamConfig{
+			{
+				DestinationName: "upstream1",
+				LocalBindPort:   ports[1],
+			},
+			{
+				DestinationName: "upstream2",
+				LocalBindPort:   ports[2],
+			},
+		},
+	}
+
+	// Check that the expected ports are listening. There are no actual upstreams
+	// so we just check that the ports are listening.
+	requirePortIsNotListening(t, ports[0])
+	requirePortIsListening(t, ports[1])
+	requirePortIsListening(t, ports[2])
+}
+
+func requirePortIsListening(t *testing.T, port int) {
+	t.Helper()
+	retry.Run(t, func(r *retry.R) {
+		conn, err := net.Dial("tcp", TestLocalAddr(port))
+		r.Check(err)
+		conn.Close()
+	})
+}
+
+func requirePortIsNotListening(t *testing.T, port int) {
+	t.Helper()
+	retry.Run(t, func(r *retry.R) {
+		conn, err := net.Dial("tcp", TestLocalAddr(port))
+		if err == nil {
+			conn.Close()
+			r.Fatalf("Port %d accepted a connection", port)
+		}
+	})
+}


### PR DESCRIPTION
This fixes two bugs in the consul connect built-in proxy:
1. It properly updates the bound ports on configuration changes, dropping unused ports, adding new ports, and re-using existing ports.
2. It properly releases ports that are no longer used.